### PR TITLE
Do not catch stream error in the promise stack.

### DIFF
--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -43,7 +43,10 @@ module.exports = function (options) {
         self.emit('end');
       })
       .catch(function (error) {
-        self.emit('error', error);
+        // need to emit in nextTick to avoid the promise catching a re-thrown error
+        process.nextTick(function () {
+          self.emit('error', error);
+        });
       });
   };
   return es.through(aggregate, scramble);


### PR DESCRIPTION
**REPEAT OF** jscrambler/gulp-jscrambler#10 :-1: This should have been merged before the creation of this repository.

--

`stream.Transform.prototype.emit` will re-throw errors when there is
no handler.

To avoid that re-throw from ending up in a "unhandled promise
rejection" it is done in the nextTick so the throw will crash the
process, encouraging implementers to handle the error.

--

In shorter terms `.pipe(jScrambler(options))` throwing an error will crash
the process instead of creating a `UnhandledPromiseRejectionWarning`.

Should have been done as part of jscrambler/gulp-jscrambler#6.