### PR TITLE
Fix output absolute path handling in grunt-jscrambler

### DIFF
--- a/packages/grunt-jscrambler/tasks/jscrambler.js
+++ b/packages/grunt-jscrambler/tasks/jscrambler.js
@@ -23,6 +23,10 @@ module.exports = function (grunt) {
     function writeFile(buffer, file) {
       files.forEach(function (elem) {
         elem.src.forEach(function (src) {
+          if(process.platform !== 'win32' && grunt.file.isPathAbsolute(src)) {
+            var parsedPath = path.parse(src);
+            src = src.replace(parsedPath.root, '');
+          }
           if (grunt.file.arePathsEquivalent(src, file)) {
             var dest = elem.dest;
             var lastDestChar = dest[dest.length - 1];
@@ -33,8 +37,6 @@ module.exports = function (grunt) {
               destPath = path.join(dest, file);
             }
             grunt.file.write(destPath, buffer);
-          } else if (elem.dest) {
-            grunt.file.write(path.join(elem.dest, file), buffer);
           }
         });
       });

--- a/packages/grunt-jscrambler/tasks/jscrambler.js
+++ b/packages/grunt-jscrambler/tasks/jscrambler.js
@@ -27,16 +27,8 @@ module.exports = function (grunt) {
             var parsedPath = path.parse(src);
             src = src.replace(parsedPath.root, '');
           }
-          if (grunt.file.arePathsEquivalent(src, file)) {
-            var dest = elem.dest;
-            var lastDestChar = dest[dest.length - 1];
-            var destPath;
-            if (elem.src.length === 1 && lastDestChar !== '/' && lastDestChar !== '\\') {
-              destPath = dest;
-            } else {
-              destPath = path.join(dest, file);
-            }
-            grunt.file.write(destPath, buffer);
+          if(grunt.file.arePathsEquivalent(src, file)) {
+            grunt.file.write(elem.dest, buffer);
           }
         });
       });


### PR DESCRIPTION
https://github.com/jscrambler/grunt-jscrambler/commit/c76f6b7cffb0188fc83eea4622cbafc9f0df8998 introduced code to handle absolute paths, but it caused the `writeFile` function to attempt to output files that didn't match the current one. This caused an error when we updated our plugin to a version that included this code.

This PR will detect an absolute path and strip the root from it. This then allows the `grunt.file.arePathsEquivalent` check to pass for an absolute path in the same way it does for a relative path.
This is only needed for posix paths, win32 paths include the root for some reason.