### PR TITLE
gulp-jscrambler: Does not Support Streams. Improve Dependencies & Readability.

### DIFF
--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -12,6 +12,7 @@ module.exports = function (options) {
   });
 
   var filesSrc = [];
+  var cwd = options && options.cwd || process.cwd();
   var aggregate = function (file, enc, next) {
     if (file.isBuffer()) {
       filesSrc.push(file);
@@ -25,6 +26,14 @@ module.exports = function (options) {
   };
   var scramble = function (done) {
     var self = this;
+    var dest = function (buffer, file) {
+      self.push(new File({
+        contents: buffer,
+        cwd: cwd,
+        path: path.join(cwd, file)
+      }))
+    };
+
     jScrambler
       .protectAndDownload({
         filesSrc: filesSrc,
@@ -37,14 +46,7 @@ module.exports = function (options) {
         port: options.port,
         params: options.params,
         jscramblerVersion: options.jscramblerVersion
-      }, function (buffer, file) {
-        var cwd = options && options.cwd || process.cwd();
-        var relativePath = path.relative(cwd, file);
-        self.push(new File({
-          path: relativePath,
-          contents: buffer
-        }));
-      })
+      }, dest)
       .then(function () {
         done(null);
       })

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -1,9 +1,9 @@
 'use strict';
 var defaults = require('lodash.defaults');
-var es = require('event-stream');
 var File = require('vinyl');
 var jScrambler = require('jscrambler').default;
 var path = require('path');
+var through = require('through2');
 
 module.exports = function (options) {
   options = defaults(options || {}, {
@@ -11,12 +11,13 @@ module.exports = function (options) {
   });
 
   var filesSrc = [];
-  var aggregate = function (file) {
+  var aggregate = function (file, enc, next) {
     if (file.contents) {
       filesSrc.push(file);
     }
+    next(null);
   };
-  var scramble = function () {
+  var scramble = function (done) {
     var self = this;
     jScrambler
       .protectAndDownload({
@@ -33,20 +34,18 @@ module.exports = function (options) {
       }, function (buffer, file) {
         var cwd = options && options.cwd || process.cwd();
         var relativePath = path.relative(cwd, file);
-        self.emit('data', new File({
+        self.push(new File({
           path: relativePath,
           contents: buffer
         }));
       })
       .then(function () {
-        self.emit('end');
+        done(null);
       })
       .catch(function (error) {
         // need to emit in nextTick to avoid the promise catching a re-thrown error
-        process.nextTick(function () {
-          self.emit('error', error);
-        });
+        process.nextTick(done, error);
       });
   };
-  return es.through(aggregate, scramble);
+  return through.obj(aggregate, scramble);
 };

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -8,11 +8,11 @@ var through = require('through2');
 
 module.exports = function (options) {
   options = defaults(options || {}, {
+    cwd: process.cwd(),
     filesSrc: [],
     keys: {}
   });
 
-  var cwd = options && options.cwd || process.cwd();
   var aggregate = function (file, enc, next) {
     if (file.isBuffer()) {
       options.filesSrc.push(file);
@@ -38,8 +38,8 @@ module.exports = function (options) {
 
       if (file === null) {
         file = new File({
-          cwd: cwd,
-          path: path.join(cwd, filename)
+          cwd: options.cwd,
+          path: path.join(options.cwd, filename)
         });
       }
 

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -26,12 +26,25 @@ module.exports = function (options) {
   };
   var scramble = function (done) {
     var self = this;
-    var dest = function (buffer, file) {
-      self.push(new File({
-        contents: buffer,
-        cwd: cwd,
-        path: path.join(cwd, file)
-      }))
+    var dest = function (buffer, filename) {
+      var file = null;
+
+      for (var src of options.filesSrc) {
+        if (src.path && src.relative === filename) {
+          file = src;
+          break;
+        }
+      }
+
+      if (file === null) {
+        file = new File({
+          cwd: cwd,
+          path: path.join(cwd, filename)
+        });
+      }
+
+      file.contents = buffer;
+      self.push(file);
     };
 
     jScrambler.protectAndDownload(options, dest).then(function () {

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -3,6 +3,7 @@ var defaults = require('lodash.defaults');
 var File = require('vinyl');
 var jScrambler = require('jscrambler').default;
 var path = require('path');
+var PluginError = require('plugin-error');
 var through = require('through2');
 
 module.exports = function (options) {
@@ -12,10 +13,15 @@ module.exports = function (options) {
 
   var filesSrc = [];
   var aggregate = function (file, enc, next) {
-    if (file.contents) {
+    if (file.isBuffer()) {
       filesSrc.push(file);
     }
-    next(null);
+    if (file.isStream()) {
+      // streaming is not supported because jscrambler-cli/src/zip.js cannot handle content streams
+      next(new PluginError('gulp-jscrambler', 'Streaming not supported'));
+    } else {
+      next(null);
+    }
   };
   var scramble = function (done) {
     var self = this;

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -47,7 +47,8 @@ module.exports = function (options) {
       self.push(file);
     };
 
-    jScrambler.protectAndDownload(options, dest).then(function () {
+    jScrambler.protectAndDownload(options, dest).then(function (protectionId) {
+      self.emit('protectionId', protectionId);
       done(null);
     }).catch(function (error) {
       // need to emit in nextTick to avoid the promise catching a re-thrown error

--- a/packages/gulp-jscrambler/package.json
+++ b/packages/gulp-jscrambler/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "jscrambler": "^5.2.8",
     "lodash.defaults": "^4.0.1",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3",
     "vinyl": "^2.1.0"
   },

--- a/packages/gulp-jscrambler/package.json
+++ b/packages/gulp-jscrambler/package.json
@@ -31,9 +31,9 @@
     "mocha": "^1.21.5"
   },
   "dependencies": {
-    "event-stream": "^3.1.5",
     "jscrambler": "^5.2.8",
     "lodash.defaults": "^4.0.1",
+    "through2": "^2.0.3",
     "vinyl": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

This pull request is opinionated, but every idea is broken up by commit. I am willing to break this up into multiple pull requests if that is helpful.

### Breaking

 * gulp-jscrambler cannot support content streams, because jscrambler-cli assumes that [contents is a buffer](https://github.com/jscrambler/jscrambler/blob/072b8cf802bbfd6c1953c13640efb0fe1475a795/packages/jscrambler-cli/src/zip.js#L52-L55). This is a problem when a user starts the pipeline with `gulp.src('**/*.js', {buffer: false})`. eb0e16c adds a conditional to check for stream mode and error when appropriate.
 * The `options` object is passed directly to the protectAndDownload method. I have always been confused why the object was manually constructed. Done by 3e30e41.

### Improvements

 * Replaced the "event-stream" dependency with "through2". This is mostly for a nicer asynchronous API. Done by e05795a.
 * Moved the destination callback before the protectAndDownload call. This allows the promise chain to be formatted more naturally. Done by 4324a11.
 * Made cwd a defaults option. Done by e43b3de.

### Features

 * Reuse existing [vinyl](https://github.com/gulpjs/vinyl) objects when possible. Done by 8bbf9cd.
 * Make the `protectionId` available by emitting an event when protectAndDownload is successful. Done by 1596cd7.

-----

I was able to make a few test passes with our current build process. Everything seemed to function as expected.