### PR TITLE
fix: unused dep lodash

### DIFF
--- a/packages/grunt-jscrambler/package.json
+++ b/packages/grunt-jscrambler/package.json
@@ -35,8 +35,7 @@
     "grunt-contrib-clean": "^0.6.0"
   },
   "dependencies": {
-    "jscrambler": "^5.2.14",
-    "lodash": "^3.10.1"
+    "jscrambler": "^5.2.14"
   },
   "keywords": [
     "gruntplugin",

--- a/packages/grunt-jscrambler/tasks/jscrambler.js
+++ b/packages/grunt-jscrambler/tasks/jscrambler.js
@@ -5,7 +5,6 @@
  */
 'use strict';
 
-var _ = require('lodash');
 var jscrambler = require('jscrambler').default;
 var path = require('path');
 var util = require('util');


### PR DESCRIPTION
Lodash dependency is triggering a security vulnerability and its not used by gulp-jscrambler module.