### PR TITLE
fix(cli): remove protocol from default config

### DIFF
--- a/packages/jscrambler-cli/src/config.js
+++ b/packages/jscrambler-cli/src/config.js
@@ -7,7 +7,6 @@ const config = rc(
   {
     keys: {},
     host: 'api4.jscrambler.com',
-    port: 443,
     jscramblerVersion: 'stable'
   },
   []


### PR DESCRIPTION
removed protocol from default config as it is set later in the code.

This will allow users to use `--protocol http` without having to specify the port.

http will map to port 80
https will map to port 443