### PR TITLE
[C-3978] Add clientId to request header

### DIFF
--- a/packages/ember-cli-jscrambler/jscrambler-plugin.js
+++ b/packages/ember-cli-jscrambler/jscrambler-plugin.js
@@ -109,7 +109,8 @@ JscramblerWriter.prototype.build = function() {
     .protectAndDownload(
       Object.assign({}, this.options.jscrambler, {
         sources,
-        stream: false
+        stream: false,
+        clientId: 5
       }),
       outputFiles => {
         outputFiles.forEach(file => {

--- a/packages/grunt-jscrambler/tasks/jscrambler.js
+++ b/packages/grunt-jscrambler/tasks/jscrambler.js
@@ -14,7 +14,8 @@ module.exports = function (grunt) {
     var done = this.async();
     var files = this.files;
     var options = this.options({
-      keys: {}
+      keys: {},
+      clientId: 4
     });
 
     options.filesSrc = this.filesSrc;

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -10,7 +10,8 @@ module.exports = function (options) {
   options = defaults(options || {}, {
     cwd: process.cwd(),
     filesSrc: [],
-    keys: {}
+    keys: {},
+    clientId: 3
   });
 
   var aggregate = function (file, enc, next) {

--- a/packages/jscrambler-cli/src/client.js
+++ b/packages/jscrambler-cli/src/client.js
@@ -17,6 +17,7 @@ const debug = !!process.env.DEBUG;
  * @param {String} options.secretKey
  * @param {String} [options.host=api.jscrambler.com]
  * @param {String} [options.port=443]
+ * @param {String} [options.clientId=0]
  * @author José Magalhães (magalhas@gmail.com)
  * @license MIT <http://opensource.org/licenses/MIT>
  */
@@ -36,11 +37,14 @@ function JScramblerClient(options) {
    */
   this.options = defaults(options || {}, cfg);
 
+  const {jscramblerVersion, clientId} = this.options;
+
   this.axiosInstance = axios.create({
     headers: {
-      jscramblerVersion: this.options.jscramblerVersion
+      jscramblerVersion,
+      clientId
     },
-    maxContentLength: 100 * 1000 * 1000, // 100 MB
+    maxContentLength: 100 * 1000 * 1000 // 100 MB
   });
 }
 /**

--- a/packages/jscrambler-cli/src/config.js
+++ b/packages/jscrambler-cli/src/config.js
@@ -8,7 +8,8 @@ const config = rc(
     keys: {},
     host: 'api4.jscrambler.com',
     jscramblerVersion: 'stable',
-    werror: true
+    werror: true,
+    clientId: 0
   },
   []
 );

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -137,7 +137,8 @@ export default {
       bail = true,
       jscramblerVersion,
       debugMode,
-      proxy
+      proxy,
+      clientId
     } = finalConfig;
 
     const {accessKey, secretKey} = keys;
@@ -150,7 +151,8 @@ export default {
       protocol,
       cafile,
       jscramblerVersion,
-      proxy
+      proxy,
+      clientId
     });
 
     let filesSrc = finalConfig.filesSrc;
@@ -633,7 +635,8 @@ export default {
   async createApplicationProtection(
     client,
     applicationId,
-    protectionOptions
+    protectionOptions,
+    fragments
   ) {
     const {args} = await introspection.mutation(
       client,
@@ -642,7 +645,7 @@ export default {
 
     const mutation = await mutations.createApplicationProtection(
       applicationId,
-      undefined,
+      fragments,
       protectionOptions,
       args
     );

--- a/packages/jscrambler-webpack-plugin/src/index.js
+++ b/packages/jscrambler-webpack-plugin/src/index.js
@@ -7,7 +7,10 @@ class JscramblerPlugin {
   constructor(_options) {
     let options = _options;
     if (typeof options !== 'object' || Array.isArray(options)) options = {};
-    this.options = options;
+
+    this.options = Object.assign(options, {
+      clientId: 2
+    });
 
     this.processResult = this.processResult.bind(this);
     this.processSourceMaps = this.processSourceMaps.bind(this);


### PR DESCRIPTION
Updated `jscrambler-cli` to send a `clientId` on each request. Every client will have a different `clientId`.