### PR TITLE
chore(JscramblerPlugin): replace deprecated plugin() call with hooks.emit.tapAsync()

### DIFF
--- a/packages/jscrambler-webpack-plugin/src/index.js
+++ b/packages/jscrambler-webpack-plugin/src/index.js
@@ -24,7 +24,7 @@ class JscramblerPlugin {
       return;
     }
 
-    compiler.plugin('emit', (compilation, callback) => {
+    compiler.hooks.emit.tapAsync('JscramblerPlugin', (compilation, callback) => {
       const sources = [];
       compilation.chunks.forEach(chunk => {
         if (


### PR DESCRIPTION
Removes deprecation message that is shown when using the plugin