### PR TITLE
fix(create-application-protection): add default options value when cleaning input fields

### DIFF
--- a/packages/jscrambler-cli/src/cleanup-input-fields.js
+++ b/packages/jscrambler-cli/src/cleanup-input-fields.js
@@ -1,4 +1,4 @@
-export default function cleanupInputFields(args, fragments, options) {
+export default function cleanupInputFields(args, fragments, options = {}) {
   let cleanedUpFragments = fragments;
 
   // tolerateMinification


### PR DESCRIPTION
Avoid TypeError with checking for options.tolereteMinification 