### PR TITLE
feat(cli): add option code hardening threshold

### DIFF
--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -33,6 +33,7 @@
     "axios": "^0.18.0",
     "babel-polyfill": "^6.9.1",
     "commander": "^2.8.1",
+    "filesize-parser": "1.5.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.3",
     "jszip": "^2.6.0",

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -106,11 +106,14 @@ config.werror = commander.werror ? commander.werror !== 'false' : config.werror;
 config.jscramblerVersion =
   commander.jscramblerVersion || config.jscramblerVersion;
 config.debugMode = commander.debugMode || config.debugMode;
-config.codeHardeningThreshold =
-  commander.codeHardeningThreshold ||
-  (config.codeHardeningThreshold
+// handle codeHardening = 0
+if (typeof commander.codeHardeningThreshold === 'undefined') {
+  config.codeHardeningThreshold = config.codeHardeningThreshold
     ? validateCodeHardeningThreshold(config.codeHardeningThreshold)
-    : undefined);
+    : undefined;
+} else {
+  config.codeHardeningThreshold = commander.codeHardeningThreshold;
+}
 
 if (config.jscramblerVersion && !/^(?:\d+\.\d+(?:-f)?|stable|latest)$/.test(config.jscramblerVersion)) {
   console.error(

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -19,15 +19,17 @@ const validateBool = option => val => {
   return val.toLowerCase();
 };
 
-const validateFileSizeFormat = option => val => {
+const validateCodeHardeningThreshold = val => {
+  let inBytes;
   try {
-    return filesizeParser(val);
+    inBytes = filesizeParser(val);
   } catch (e) {
     console.error(
-      `*${option}* requires a valid <threshold> value. Format: {number}{unit="b,kb,mb"}. Example: --code-hardening-threshold 200kb`
+      '*code-hardening-threshold* requires a valid <threshold> value. Format: {number}{unit="b,kb,mb"}. Example: --code-hardening-threshold 200kb'
     );
     process.exit(1);
   }
+  return inBytes;
 };
 
 commander
@@ -48,7 +50,7 @@ commander
   .option(
     '--code-hardening-threshold <threshold>',
     'Set code hardening file size threshold. Format: {value}{unit="b,kb,mb"}. Example: 200kb',
-    validateFileSizeFormat('code-hardening-threshold')
+    validateCodeHardeningThreshold
   )
   .option(
     '--recommended-order <bool>',
@@ -105,7 +107,10 @@ config.jscramblerVersion =
   commander.jscramblerVersion || config.jscramblerVersion;
 config.debugMode = commander.debugMode || config.debugMode;
 config.codeHardeningThreshold =
-  commander.codeHardeningThreshold || config.codeHardeningThreshold;
+  commander.codeHardeningThreshold ||
+  (config.codeHardeningThreshold
+    ? validateCodeHardeningThreshold(config.codeHardeningThreshold)
+    : undefined);
 
 if (config.jscramblerVersion && !/^(?:\d+\.\d+(?:-f)?|stable|latest)$/.test(config.jscramblerVersion)) {
   console.error(

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -19,7 +19,7 @@ const validateBool = option => val => {
   return val.toLowerCase();
 };
 
-const validateFIleSizeInput = option => val => {
+const validateFileSizeFormat = option => val => {
   try {
     return filesizeParser(val);
   } catch (e) {
@@ -48,7 +48,7 @@ commander
   .option(
     '--code-hardening-threshold <threshold>',
     'Set code hardening file size threshold. Format: {value}{unit="b,kb,mb"}. Example: 200kb',
-    validateFIleSizeInput('code-hardening-threshold')
+    validateFileSizeFormat('code-hardening-threshold')
   )
   .option(
     '--recommended-order <bool>',

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -139,7 +139,8 @@ export default {
       debugMode,
       proxy,
       clientId,
-      tolerateMinification
+      tolerateMinification,
+      codeHardeningThreshold
     } = finalConfig;
 
     const {accessKey, secretKey} = keys;
@@ -241,7 +242,8 @@ export default {
     const updateData = {
       _id: applicationId,
       debugMode: !!debugMode,
-      tolerateMinification
+      tolerateMinification,
+      codeHardeningThreshold
     };
 
     if (params && Object.keys(params).length) {

--- a/packages/jscrambler-cli/src/mutations.js
+++ b/packages/jscrambler-cli/src/mutations.js
@@ -355,8 +355,6 @@ export function createApplicationProtection(
     };
   }
 
-  console.log(options);
-
   // Check if createApplicationProtection supports "data" argument
   if (args.some(arg => arg.name === 'data')) {
     return {

--- a/packages/jscrambler-cli/src/mutations.js
+++ b/packages/jscrambler-cli/src/mutations.js
@@ -355,6 +355,8 @@ export function createApplicationProtection(
     };
   }
 
+  console.log(options);
+
   // Check if createApplicationProtection supports "data" argument
   if (args.some(arg => arg.name === 'data')) {
     return {


### PR DESCRIPTION
New option code hardening threshold which receives a string with a specific format: {number}{unit='b,kb,mb'}