### PR TITLE
Added commander for argv handling

### DIFF
--- a/packages/jscrambler-metro-plugin/lib/index.js
+++ b/packages/jscrambler-metro-plugin/lib/index.js
@@ -1,5 +1,6 @@
 const {emptyDir, mkdirp, readFile, writeFile} = require('fs-extra');
 const jscrambler = require('jscrambler').default;
+const commander = require('commander');
 const fs = require('fs');
 const path = require('path');
 
@@ -13,10 +14,9 @@ const JSCRAMBLER_END_ANNOTATION = '"JSCRAMBLER-END";';
 const JSCRAMBLER_EXTS = ['.js', '.jsx'];
 
 function getBundlePath() {
-  for (let i = 0; i < process.argv.length; i++) {
-    if (process.argv[i] === BUNDLE_OUTPUT_CLI_ARG) {
-      return process.argv[i + 1];
-    }
+  commander.option(`${BUNDLE_OUTPUT_CLI_ARG} <string>`).parse(process.argv);
+  if (commander.bundleOutput) {
+    return commander.bundleOutput;
   }
   console.error('Bundle output path not found.');
   return process.exit(-1);

--- a/packages/jscrambler-metro-plugin/package.json
+++ b/packages/jscrambler-metro-plugin/package.json
@@ -4,6 +4,7 @@
   "description": "A plugin to use metro with Jscrambler",
   "main": "lib/index.js",
   "dependencies": {
+    "commander": "^2.20.0",
     "fs-extra": "^8.0.1",
     "jscrambler": "^5.3.5"
   },


### PR DESCRIPTION
Commander helps us read `bundle-output` argument from argv if it is entered in any of the following ways:

`node node_modules/react-native/local-cli/cli.js bundle --entry-file='index.js' --bundle-output='./ios/main.jsbundle' --dev=true --platform='ios' --assets-dest='./ios'`

`node node_modules/react-native/local-cli/cli.js bundle --entry-file index.js --bundle-output ./ios/main.jsbundle --dev true --platform ios --assets-dest ./ios`.

Right now, if bundle command is invoked in the first way we get an error.