### PR TITLE
fix: respect CLI useProfilingData: false

### DIFF
--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -119,9 +119,10 @@ if (typeof commander.codeHardeningThreshold === 'undefined') {
 } else {
   config.codeHardeningThreshold = commander.codeHardeningThreshold;
 }
-config.useProfilingData = commander.useProfilingData
-  ? commander.useProfilingData !== 'false'
-  : config.useProfilingData || true;
+
+if (commander.useProfilingData) {
+  config.useProfilingData = commander.useProfilingData !== 'false';
+}
 
 if (config.jscramblerVersion && !/^(?:\d+\.\d+(?:-f)?|stable|latest)$/.test(config.jscramblerVersion)) {
   console.error(

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -244,8 +244,7 @@ export default {
       _id: applicationId,
       debugMode: !!debugMode,
       tolerateMinification,
-      codeHardeningThreshold,
-      useProfilingData
+      codeHardeningThreshold
     };
 
     if (params && Object.keys(params).length) {
@@ -271,6 +270,10 @@ export default {
 
     if (typeof sourceMaps !== 'undefined') {
       updateData.sourceMaps = sourceMaps;
+    }
+
+    if (useProfilingData !== undefined) {
+      updateData.useProfilingData = useProfilingData;
     }
 
     if (


### PR DESCRIPTION
Prevent `useProfilingData: false` from being ignored and set to true.
Now, false/undefined are propagated to the sent data.