### PR TITLE
fix(axios): upgrade axios to properly work with proxy + https

### DIFF
--- a/packages/jscrambler-cli/README.md
+++ b/packages/jscrambler-cli/README.md
@@ -251,24 +251,6 @@ If your requests need to go through a proxy, there is an option where you can sp
   }
 }
 
-```
-
-WARNING: currently we only support HTTP proxies. In order to make it use your proxy, you just need to add the proxy details to the Jscrambler config file as above and use the port 80 of our service (this is the HTTP port of the Jscrambler API).
-
-```
-{
-  port: 80,
-  proxy: {
-      host: '',
-      port: 1234,
-      auth: {
-        username: '',
-        password: ''
-      }
-  }
-}
-```
-
 ### Recommended Order (default: **false**)
 ```bash
 jscrambler --recommended-order false input1.js -o output/

--- a/packages/jscrambler-cli/README.md
+++ b/packages/jscrambler-cli/README.md
@@ -250,6 +250,7 @@ If your requests need to go through a proxy, there is an option where you can sp
     }
   }
 }
+```
 
 ### Recommended Order (default: **false**)
 ```bash

--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -30,7 +30,7 @@
     "node": ">= 6.10.0"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.1",
     "babel-polyfill": "^6.9.1",
     "commander": "^2.8.1",
     "filesize-parser": "1.5.0",


### PR DESCRIPTION
Closes JIRA-ST-502.

Axios module needs to be in the latest version to properly work with proxy + https settings