### PR TITLE
fix(metro): skip obfuscation for non-bundle commands

### DIFF
--- a/packages/jscrambler-metro-plugin/README.md
+++ b/packages/jscrambler-metro-plugin/README.md
@@ -2,6 +2,8 @@
 
 This metro plugin protects your React Native bundle using Jscrambler.
 
+> Note: Only protects source code triggered by `bundle` react-native command.
+
 # Usage
 
 Include the plugin in your `metro.config.js` and add the following code:
@@ -26,3 +28,5 @@ module.exports = jscramblerMetroPlugin;
 
 You can pass your Jscrambler configuration using the plugin parameter or using
 the usual `.jscramblerrc` file.
+
+By default, Jscrambler protection is **ignored** when bundle mode is set for **Development**. You can override this behaviour by setting env variable `JSCRAMBLER_METRO_DEV=true` 

--- a/packages/jscrambler-metro-plugin/lib/index.js
+++ b/packages/jscrambler-metro-plugin/lib/index.js
@@ -1,6 +1,6 @@
 const {emptyDir, remove, mkdirp, readFile, writeFile} = require('fs-extra');
 const jscrambler = require('jscrambler').default;
-const commander = require('commander');
+const {Command} = require('commander');
 const fs = require('fs');
 const path = require('path');
 const metroSourceMap = require('metro-source-map');
@@ -23,18 +23,20 @@ const JSCRAMBLER_EXTS = /.(j|t)s(x)?$/i;
  */
 function skipObfuscation() {
   let isBundleCmd = false;
-  commander
+  const command = new Command();
+  command
     .command(BUNDLE_CMD)
     .allowUnknownOption()
     .action(() => (isBundleCmd = true));
-  commander.parse(process.argv);
+  command.parse(process.argv);
   return !isBundleCmd;
 }
 
 function getBundlePath() {
-  commander.option(`${BUNDLE_OUTPUT_CLI_ARG} <string>`).parse(process.argv);
-  if (commander.bundleOutput) {
-    return commander.bundleOutput;
+  const command = new Command();
+  command.option(`${BUNDLE_OUTPUT_CLI_ARG} <string>`).parse(process.argv);
+  if (command.bundleOutput) {
+    return command.bundleOutput;
   }
   console.error('Bundle output path not found.');
   return process.exit(-1);

--- a/packages/jscrambler-metro-plugin/lib/index.js
+++ b/packages/jscrambler-metro-plugin/lib/index.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const metroSourceMap = require('metro-source-map');
 
+const BUNDLE_CMD = 'bundle';
 const BUNDLE_OUTPUT_CLI_ARG = '--bundle-output';
 
 const JSCRAMBLER_CLIENT_ID = 6;
@@ -15,6 +16,20 @@ const JSCRAMBLER_PROTECTION_ID_FILE = `${JSCRAMBLER_TEMP_FOLDER}/protectionId`;
 const JSCRAMBLER_BEG_ANNOTATION = '"JSCRAMBLER-BEG";';
 const JSCRAMBLER_END_ANNOTATION = '"JSCRAMBLER-END";';
 const JSCRAMBLER_EXTS = /.(j|t)s(x)?$/i;
+
+/**
+ * Only 'bundle' command triggers obfuscation
+ * @returns {boolean} true skips Jscrambler obfuscation
+ */
+function skipObfuscation() {
+  let isBundleCmd = false;
+  commander
+    .command(BUNDLE_CMD)
+    .allowUnknownOption()
+    .action(() => (isBundleCmd = true));
+  commander.parse(process.argv);
+  return !isBundleCmd;
+}
 
 function getBundlePath() {
   commander.option(`${BUNDLE_OUTPUT_CLI_ARG} <string>`).parse(process.argv);
@@ -134,6 +149,10 @@ function buildModuleSourceMap(output, modulePath, source) {
 }
 
 module.exports = function(_config = {}, projectRoot = process.cwd()) {
+  if (skipObfuscation()) {
+    console.log('warn Jscrambler Obfuscation SKIPPED');
+    return {};
+  }
   const bundlePath = getBundlePath();
   const fileNames = new Set();
   const sourceMapFiles = [];


### PR DESCRIPTION
only `bundle` command should trigger obfuscation process