### PR TITLE
[jscrambler-webpack-plugin] Add .jscramblerignore file to sources if exists

### DIFF
--- a/packages/jscrambler-webpack-plugin/src/index.js
+++ b/packages/jscrambler-webpack-plugin/src/index.js
@@ -36,6 +36,19 @@ class JscramblerPlugin {
 
     compiler.plugin('emit', (compilation, callback) => {
       const sources = [];
+      
+      try {
+        const ignoreFilename = '.jscramblerignore';
+        const ignorePatterns = fs.readFileSync(ignoreFilename, { encoding: 'utf8' });
+
+        sources.push({ 
+          content: ignorePatterns, 
+          filename: ignoreFilename,
+        });
+      } catch (error) {
+        // .jscramblerignore file does not exist
+      }
+      
       compilation.chunks.forEach(chunk => {
         if (
           Array.isArray(this.options.chunks) &&
@@ -45,18 +58,6 @@ class JscramblerPlugin {
         }
 
         chunk.files.forEach(filename => {
-          try {
-            const ignoreFilename = '.jscramblerignore';
-            const ignorePatterns = fs.readFileSync(ignoreFilename, { encoding: 'utf8' });
-            
-            sources.push({ 
-              content: ignorePatterns, 
-              filename: ignoreFilename,
-            });
-          } catch (error) {
-            // .jscramblerignore file does not exist
-          }
-          
           if (/\.(js|html|htm)$/.test(filename)) {
             const content = compilation.assets[filename].source();
 

--- a/packages/jscrambler-webpack-plugin/src/index.js
+++ b/packages/jscrambler-webpack-plugin/src/index.js
@@ -1,5 +1,6 @@
 const client = require('jscrambler').default;
 const {SourceMapSource} = require('webpack-sources');
+const fs = require('fs');
 
 const sourceMaps = !!client.config.sourceMaps;
 const instrument = !!client.config.instrument;
@@ -44,6 +45,18 @@ class JscramblerPlugin {
         }
 
         chunk.files.forEach(filename => {
+          try {
+            const ignoreFilename = '.jscramblerignore';
+            const ignorePatterns = fs.readFileSync(ignoreFilename, { encoding: 'utf8' });
+            
+            sources.push({ 
+              content: ignorePatterns, 
+              filename: ignoreFilename,
+            });
+          } catch (error) {
+            // .jscramblerignore file does not exist
+          }
+          
           if (/\.(js|html|htm)$/.test(filename)) {
             const content = compilation.assets[filename].source();
 


### PR DESCRIPTION
Hello, I have a question about 'jscrambler-webpack-plugin'. It's said that to exclude from the file to be protected, the `.jscramblerignore` file must be transferred to the API as shown in the document below.
https://docs.jscrambler.com/code-integrity/documentation/ignoring-files

Is there any way to configure webpack plugin to support this? If not, can you please consider applying this change?

Thank you.