### PR TITLE
fix(metro-plugin): stop automatically enable of source maps

### DIFF
--- a/packages/jscrambler-metro-plugin/lib/index.js
+++ b/packages/jscrambler-metro-plugin/lib/index.js
@@ -79,13 +79,15 @@ async function obfuscateBundle(
   config.cwd = JSCRAMBLER_SRC_TEMP_FOLDER;
   config.clientId = JSCRAMBLER_CLIENT_ID;
     
-  if(bundleSourceMapPath && config.sourceMaps === undefined) {
-    throw `Metro is generating source maps that won't be useful after Jscrambler protection.
-    If this is not a problem, you can either: 
-      1) Disable source maps in metro bundler. 
-      2) Explicitly disable Jscrambler source maps by adding 'sourceMaps: false' in the Jscrambler config file.
-    
-    If you want valid source maps, make sure you have access to the feature and enable it in jscrambler config file by adding 'sourceMaps: true'`
+  if (bundleSourceMapPath && typeof config.sourceMaps === 'undefined') {
+    console.error(`error Metro is generating source maps that won't be useful after Jscrambler protection.
+  If this is not a problem, you can either:
+    1) Disable source maps in metro bundler
+    2) Explicitly disable Jscrambler source maps by adding 'sourceMaps: false' in the Jscrambler config file
+
+  If you want valid source maps, make sure you have access to the feature and enable it in Jscrambler config file by adding 'sourceMaps: true'`
+    );
+    process.exit(-1);
   }
   
   const shouldGenerateSourceMaps = config.sourceMaps && bundleSourceMapPath;

--- a/packages/jscrambler-metro-plugin/lib/index.js
+++ b/packages/jscrambler-metro-plugin/lib/index.js
@@ -78,9 +78,16 @@ async function obfuscateBundle(
   config.filesDest = JSCRAMBLER_DIST_TEMP_FOLDER;
   config.cwd = JSCRAMBLER_SRC_TEMP_FOLDER;
   config.clientId = JSCRAMBLER_CLIENT_ID;
-  // if omit, we automatically activate sourceMaps generation (no sourceContent) when '--sourcemap-output' arg is set
-  config.sourceMaps = config.sourceMaps === undefined ? !!bundleSourceMapPath : config.sourceMaps;
-  // must have metro and jscrambler source-maps
+    
+  if(bundleSourceMapPath && config.sourceMaps === undefined) {
+    throw `Metro is generating source maps that won't be useful after Jscrambler protection.
+    If this is not a problem, you can either: 
+      1) Disable source maps in metro bundler. 
+      2) Explicitly disable Jscrambler source maps by adding 'sourceMaps: false' in the Jscrambler config file.
+    
+    If you want valid source maps, make sure you have access to the feature and enable it in jscrambler config file by adding 'sourceMaps: true'`
+  }
+  
   const shouldGenerateSourceMaps = config.sourceMaps && bundleSourceMapPath;
 
   const jscramblerOp = !!config.instrument


### PR DESCRIPTION
This caused an error ('You don't have access to this feature') in every user that din't have access to the it. After the error, the user had no information about how to proceed. 
Now we throw an error with instructions about how to solve the problem.