### PR TITLE
Retry http requests when faced with gateway timeouts

### DIFF
--- a/packages/jscrambler-cli/src/config.js
+++ b/packages/jscrambler-cli/src/config.js
@@ -10,7 +10,8 @@ const config = rc(
     basePath: '',
     jscramblerVersion: 'stable',
     werror: true,
-    clientId: 0
+    clientId: 0,
+    maxRetries: 5
   },
   []
 );

--- a/packages/jscrambler-cli/src/constants.js
+++ b/packages/jscrambler-cli/src/constants.js
@@ -1,0 +1,6 @@
+export const HTTP_STATUS_CODES = Object.freeze({
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504
+});


### PR DESCRIPTION
Particularly busy VMs can sometimes fail to answer to a request in time.
This is massively annoying during polling as any polling failure can stop the CLI.