### PR TITLE
fix: issue that was causing entryPoint to break on windows

### DIFF
--- a/packages/jscrambler-metro-plugin/lib/constants.js
+++ b/packages/jscrambler-metro-plugin/lib/constants.js
@@ -1,8 +1,11 @@
+const path = require('path');
+
 const BUNDLE_CMD = 'bundle';
 const BUNDLE_OUTPUT_CLI_ARG = '--bundle-output';
 const BUNDLE_SOURCEMAP_OUTPUT_CLI_ARG = '--sourcemap-output';
 const BUNDLE_DEV_CLI_ARG = '--dev';
-const INIT_CORE_MODULE = 'node_modules/react-native/Libraries/Core/InitializeCore.js';
+// path.join so it supports both linux and windows fs
+const INIT_CORE_MODULE = path.join(process.platform === 'win32' ? '/' : '', 'node_modules', 'react-native', 'Libraries', 'Core', 'InitializeCore.js');
 const JSCRAMBLER_CLIENT_ID = 6;
 const JSCRAMBLER_TEMP_FOLDER = '.jscrambler';
 const JSCRAMBLER_DIST_TEMP_FOLDER = `${JSCRAMBLER_TEMP_FOLDER}/dist`;


### PR DESCRIPTION
INIT_CORE_MODULE must use POSIX file notation.