### PR TITLE
feat(cli): add new option to support app environment overriding

### DIFF
--- a/packages/jscrambler-cli/README.md
+++ b/packages/jscrambler-cli/README.md
@@ -111,6 +111,7 @@ Options:
   --jscramblerVersion <version>           Use a specific Jscrambler version
   --debugMode                             Protect in debug mode
   --skip-sources                          Prevent source files from being updated
+  --force-app-environment <environment>   (version 7.1 and above) Override application's environment detected automatically. Possible values: node,browser,isomorphic,automatic
   -h, --help                              output usage information
 ```
 

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -48,7 +48,7 @@ const validateProfilingDataMode = mode => {
 };
 
 const validateForceAppEnvironment = env => {
-  const availableEnvironments = ['automatic', 'node', 'browser', 'hybrid'];
+  const availableEnvironments = ['automatic', 'node', 'browser', 'isomorphic'];
 
   const normalizeEnvironment = env.toLowerCase();
 

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -48,7 +48,7 @@ const validateProfilingDataMode = mode => {
 };
 
 const validateForceAppEnvironment = env => {
-  const availableEnvironments = ['node', 'browser', 'isomorphic'];
+  const availableEnvironments = ['none', 'node', 'browser', 'isomorphic'];
 
   const normalizeEnvironment = env.toLowerCase();
 

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -229,7 +229,7 @@ if (commander.forceAppEnvironment) {
 } else {
   config.forceAppEnvironment =
     config.forceAppEnvironment ?
-    validateforceAppEnvironment(config.forceAppEnvironment) :
+    validateForceAppEnvironment(config.forceAppEnvironment) :
     undefined;
 }
 

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -48,7 +48,7 @@ const validateProfilingDataMode = mode => {
 };
 
 const validateForceAppEnvironment = env => {
-  const availableEnvironments = ['none', 'node', 'browser', 'isomorphic'];
+  const availableEnvironments = ['automatic', 'node', 'browser', 'isomorphic'];
 
   const normalizeEnvironment = env.toLowerCase();
 

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -47,9 +47,8 @@ const validateProfilingDataMode = mode => {
   return normalizedMode;
 };
 
+const availableEnvironments = ['node', 'browser', 'isomorphic', 'automatic'];
 const validateForceAppEnvironment = env => {
-  const availableEnvironments = ['automatic', 'node', 'browser', 'isomorphic'];
-
   const normalizeEnvironment = env.toLowerCase();
 
   if (!availableEnvironments.includes(normalizeEnvironment)) {
@@ -135,7 +134,7 @@ commander
   .option('--skip-sources', 'Prevent source files from being updated')
   .option(
     '--force-app-environment <environment>',
-    'Override application\'s environment detected automatically',
+    `(version 7.1 and above) Override application\'s environment detected automatically. Possible values: ${availableEnvironments.toString()}`,
     validateForceAppEnvironment
   )
   .parse(process.argv);
@@ -214,14 +213,6 @@ if (config.jscramblerVersion && !/^(?:\d+\.\d+(?:-f)?|stable|latest)$/.test(conf
     'The Jscrambler version must be in the form of $major.$minor or the words stable and latest. (e.g. 5.2, stable, latest)'
   );
   process.exit(1);
-}
-
-if (commander.profilingDataMode) {
-  config.profilingDataMode = commander.profilingDataMode;
-} else {
-  config.profilingDataMode = config.profilingDataMode ?
-  validateProfilingDataMode(config.profilingDataMode) :
-  undefined;
 }
 
 if (commander.forceAppEnvironment) {

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -47,6 +47,21 @@ const validateProfilingDataMode = mode => {
   return normalizedMode;
 };
 
+const validateForceAppEnvironment = env => {
+  const availableEnvironments = ['node', 'browser', 'isomorphic'];
+
+  const normalizeEnvironment = env.toLowerCase();
+
+  if (!availableEnvironments.includes(normalizeEnvironment)) {
+    console.error(
+      `*force-app-environment* requires one of the following values: {${availableEnvironments.toString()}}. Example: --force-app-environment ${availableEnvironments[0]}`
+    );
+    process.exit(1);
+  }
+
+  return normalizeEnvironment;
+};
+
 commander
   .version(require('../../package.json').version)
   .usage('[options] <file ...>')
@@ -118,6 +133,11 @@ commander
   .option('--jscramblerVersion <version>', 'Use a specific Jscrambler version')
   .option('--debugMode', 'Protect in debug mode')
   .option('--skip-sources', 'Prevent source files from being updated')
+  .option(
+    '--force-app-environment <environment>',
+    'Override application\'s environment detected automatically',
+    validateForceAppEnvironment
+  )
   .parse(process.argv);
 
 let globSrc, filesSrc, config;
@@ -194,6 +214,23 @@ if (config.jscramblerVersion && !/^(?:\d+\.\d+(?:-f)?|stable|latest)$/.test(conf
     'The Jscrambler version must be in the form of $major.$minor or the words stable and latest. (e.g. 5.2, stable, latest)'
   );
   process.exit(1);
+}
+
+if (commander.profilingDataMode) {
+  config.profilingDataMode = commander.profilingDataMode;
+} else {
+  config.profilingDataMode = config.profilingDataMode ?
+  validateProfilingDataMode(config.profilingDataMode) :
+  undefined;
+}
+
+if (commander.forceAppEnvironment) {
+  config.forceAppEnvironment = commander.forceAppEnvironment;
+} else {
+  config.forceAppEnvironment =
+    config.forceAppEnvironment ?
+    validateforceAppEnvironment(config.forceAppEnvironment) :
+    undefined;
 }
 
 config = defaults(config, _config);
@@ -291,7 +328,8 @@ const {
   skipSources,
   inputSymbolTable,
   utc,
-  entryPoint
+  entryPoint,
+  forceAppEnvironment
 } = config;
 
 const params = mergeAndParseParams(commander, config.params);
@@ -423,7 +461,8 @@ if (commander.sourceMaps) {
       skipSources,
       removeProfilingData,
       inputSymbolTable,
-      entryPoint
+      entryPoint,
+      forceAppEnvironment
     };
     try {
       if (typeof werror !== 'undefined') {

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -48,7 +48,7 @@ const validateProfilingDataMode = mode => {
 };
 
 const validateForceAppEnvironment = env => {
-  const availableEnvironments = ['automatic', 'node', 'browser', 'isomorphic'];
+  const availableEnvironments = ['automatic', 'node', 'browser', 'hybrid'];
 
   const normalizeEnvironment = env.toLowerCase();
 

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -319,8 +319,7 @@ export default {
       _id: applicationId,
       debugMode: !!debugMode,
       tolerateMinification,
-      codeHardeningThreshold,
-      forceAppEnvironment: 'automatic'
+      codeHardeningThreshold
     };
 
     if (params && Object.keys(params).length) {
@@ -338,8 +337,7 @@ export default {
       sourceMaps,
       useAppClassification,
       useProfilingData,
-      useRecommendedOrder,
-      forceAppEnvironment
+      useRecommendedOrder
     };
 
     for (const prop in dataToValidate) {
@@ -354,7 +352,6 @@ export default {
       updateData.applicationTypes ||
       updateData.languageSpecifications ||
       updateData.browsers ||
-      updateData.forceAppEnvironment||
       typeof updateData.areSubscribersOrdered !== 'undefined'
     ) {
       if (debug) {
@@ -389,7 +386,8 @@ export default {
       inputSymbolTable,
       randomizationSeed,
       source,
-      tolerateMinification
+      tolerateMinification,
+      forceAppEnvironment
     };
 
     if (finalConfig.inputSymbolTable) {

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -319,7 +319,8 @@ export default {
       _id: applicationId,
       debugMode: !!debugMode,
       tolerateMinification,
-      codeHardeningThreshold
+      codeHardeningThreshold,
+      forceAppEnvironment: 'none'
     };
 
     if (params && Object.keys(params).length) {

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -248,7 +248,8 @@ export default {
       removeProfilingData,
       skipSources,
       inputSymbolTable,
-      entryPoint
+      entryPoint,
+      forceAppEnvironment
     } = finalConfig;
 
     const {accessKey, secretKey} = keys;
@@ -336,7 +337,8 @@ export default {
       sourceMaps,
       useAppClassification,
       useProfilingData,
-      useRecommendedOrder
+      useRecommendedOrder,
+      forceAppEnvironment
     };
 
     for (const prop in dataToValidate) {
@@ -351,6 +353,7 @@ export default {
       updateData.applicationTypes ||
       updateData.languageSpecifications ||
       updateData.browsers ||
+      updateData.forceAppEnvironment||
       typeof updateData.areSubscribersOrdered !== 'undefined'
     ) {
       if (debug) {

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -320,7 +320,7 @@ export default {
       debugMode: !!debugMode,
       tolerateMinification,
       codeHardeningThreshold,
-      forceAppEnvironment: 'none'
+      forceAppEnvironment: 'automatic'
     };
 
     if (params && Object.keys(params).length) {


### PR DESCRIPTION
Adds a new option * force-app-environment* that allows user to override the application's environment. Application environment detection an automatic process.