### PR TITLE
fix: bug on windows preventing react native protections

### DIFF
--- a/packages/jscrambler-metro-plugin/lib/utils.js
+++ b/packages/jscrambler-metro-plugin/lib/utils.js
@@ -188,7 +188,11 @@ function buildNormalizePath(path, projectRoot) {
     return;
   }
   const relativePath = path.replace(projectRoot, '');
-  return relativePath.replace(JSCRAMBLER_EXTS, '.js').substring(1 /* remove '/' */);
+  const relativePathWithLeadingSlash = relativePath.replace(JSCRAMBLER_EXTS, '.js');
+  if (process.platform === 'win32') {
+    return relativePathWithLeadingSlash;
+  }
+  return relativePathWithLeadingSlash.substring(1 /* remove '/' */);
 }
 
 function getCodeBody(code) {


### PR DESCRIPTION
On Windows, the entry point should include a backslash at the front of the filename, otherwise RN doesn't build.