### PR TITLE
fix(metro-plugin): update regex to handle non minified bundles

### DIFF
--- a/packages/jscrambler-metro-plugin/lib/index.js
+++ b/packages/jscrambler-metro-plugin/lib/index.js
@@ -256,6 +256,8 @@ module.exports = function (_config = {}, projectRoot = process.cwd()) {
   }
 
   const bundlePath = getBundlePath();
+  // make sure jscrambler-metro-plugin is properly configure on metro bundler
+  let calledByMetro = false;
   const fileNames = new Set();
   const sourceMapFiles = [];
   const config = Object.assign({}, jscrambler.config, _config);
@@ -272,6 +274,10 @@ module.exports = function (_config = {}, projectRoot = process.cwd()) {
 
   process.on('beforeExit', async function (exitCode) {
     try{
+      if (!calledByMetro) {
+        throw new Error('*jscrambler-metro-plugin* was not properly configured on metro.config.js file. Please verify our documentation in https://docs.jscrambler.com/code-integrity/frameworks-and-libraries/react-native/integration.');
+      }
+
       console.log(
         instrument
           ? 'info Jscrambler Instrumenting Code'
@@ -297,6 +303,8 @@ module.exports = function (_config = {}, projectRoot = process.cwd()) {
        * @returns {boolean}
        */
       processModuleFilter(_module) {
+        calledByMetro = true;
+
         const modulePath = _module.path;
         const shouldSkipModule = !validateModule(modulePath, config, projectRoot);
 

--- a/packages/jscrambler-metro-plugin/lib/utils.js
+++ b/packages/jscrambler-metro-plugin/lib/utils.js
@@ -225,10 +225,10 @@ const isFileReadable = (path) => new Promise((resolve) => {
 })
 
 const addBundleArgsToExcludeList = (chunk, excludeList) => {
-  const regex = /\(([0-9a-zA-Z_,]+)\){$/gm;
+  const regex = /\(([0-9a-zA-Z_,$ ]+)\)[ ]?{$/gm;
   const m = regex.exec(chunk);
   if (Array.isArray(m) && m.length > 1) {
-    for (const arg of m[1].split(",")) {
+    for (const arg of m[m.length - 1].split(",")) {
       if (!excludeList.includes(arg)) {
         excludeList.push(arg);
       }


### PR DESCRIPTION
We did support bundles containing the following code:
```js
__d(function(g,r,i,a,m,e,d){
```

This code is produced when bundling for a release, running `./gradlew assembleRelease` for example.

We also want to support debug variants and, in that case the code is not minified and looks like this:

```js
__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
```

This PR updates the regex to collect these identifiers so we can support both variants.