### PR TITLE
feat(cli): update application sources at the same time that we create the protection

### DIFF
--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -588,11 +588,12 @@ export default {
     }
 
     if (!skipSources) {
-      await this.updateApplicationSources(client, applicationId, {
-        sources,
-        filesSrc,
-        cwd
+      const {promise: updateApplicationSourcePromise} = await this.updateApplicationSources(client, applicationId, {
+          sources,
+          filesSrc,
+          cwd
       });
+      await updateApplicationSourcePromise;
     } else {
       console.log('Update source files SKIPPED');
     }

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -589,9 +589,9 @@ export default {
 
     if (!skipSources) {
       const {promise: updateApplicationSourcePromise} = await this.updateApplicationSources(client, applicationId, {
-          sources,
-          filesSrc,
-          cwd
+        sources,
+        filesSrc,
+        cwd
       });
       await updateApplicationSourcePromise;
     } else {


### PR DESCRIPTION
There is no need to wait for the application to be updated since we are also sending sources on `createApplicationProtection`.
Do this in parallel so can spare some time waiting for nothing.

In the future, we can even move the updateApplicationSource to the backend and update them when are creating a new protection.