### PR TITLE
[CD-7334] instrument-and-download: correctly use updateApplicationSources function

### DIFF
--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -616,12 +616,11 @@ export default {
     }
 
     if (!skipSources) {
-      const {promise: updateApplicationSourcePromise} = await this.updateApplicationSources(client, applicationId, {
+      await this.updateApplicationSources(client, applicationId, {
         sources,
         filesSrc,
         cwd
       });
-      await updateApplicationSourcePromise;
     } else {
       console.log('Update source files SKIPPED');
     }


### PR DESCRIPTION
This bug started to happening [in this PR](https://github.com/jscrambler/jscrambler/pull/115), when we reverted a change  but forgot this use case.