### PR TITLE
Fix: updateApplication function not sending areSubscribersOrdered in data

### DIFF
--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -396,8 +396,9 @@ export default {
       );
       const updateApplicationRes = await this.updateApplication(
         client,
+        applicationUpdate,
+        undefined,
         applicationId,
-        applicationUpdate
       );
       if (debug) {
         console.log('Finished updating parameters of protection');
@@ -1048,8 +1049,8 @@ export default {
     return client.post('/application', mutation);
   },
   //
-  async updateApplication(client, applicationId, applicationData, fragments) {
-    const mutation = await mutations.updateApplication(applicationId, applicationData, fragments);
+  async updateApplication(client, applicationData, fragments, applicationId) {
+    const mutation = await mutations.updateApplication(applicationData, fragments, applicationId);
     return client.post('/application', mutation);
   },
   //

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -347,7 +347,6 @@ export default {
     }
 
     const updateData = {
-      _id: applicationId,
       debugMode: !!debugMode,
       tolerateMinification,
       codeHardeningThreshold
@@ -393,10 +392,11 @@ export default {
       const applicationUpdate = await intoObjectType(
         client,
         updateData,
-        'Application'
+        'ApplicationUpdate'
       );
       const updateApplicationRes = await this.updateApplication(
         client,
+        applicationId,
         applicationUpdate
       );
       if (debug) {
@@ -410,7 +410,6 @@ export default {
       console.log('Creating Application Protection');
     }
 
-    delete updateData._id;
     const protectionOptions = {
       ...updateData,
       bail,
@@ -1049,8 +1048,8 @@ export default {
     return client.post('/application', mutation);
   },
   //
-  async updateApplication(client, application, fragments) {
-    const mutation = await mutations.updateApplication(application, fragments);
+  async updateApplication(client, applicationId, applicationData, fragments) {
+    const mutation = await mutations.updateApplication(applicationId, applicationData, fragments);
     return client.post('/application', mutation);
   },
   //

--- a/packages/jscrambler-cli/src/introspection.js
+++ b/packages/jscrambler-cli/src/introspection.js
@@ -86,7 +86,6 @@ fragment TypeRef on __Type {
   };
 
   const res = await client.get('/application', query);
-
   const __type = res.data.__type;
 
   typeCache[jscramblerVersion][__type.name] = __type;
@@ -111,7 +110,8 @@ export async function query(client, name) {
 }
 
 export async function intoObjectType(client, obj, name) {
-  const fields = (await type(client, name)).fields;
+  const resultType = (await type(client, name));
+  const fields = resultType.fields ?? resultType.inputFields;
 
   const finalObj = {};
   const keys = Object.keys(obj);

--- a/packages/jscrambler-cli/src/mutations.js
+++ b/packages/jscrambler-cli/src/mutations.js
@@ -123,12 +123,10 @@ const updateApplicationDefaultFragments = `
 `;
 
 export function updateApplication(
-  application,
+  applicationId,
+  applicationData,
   fragments = updateApplicationDefaultFragments
 ) {
-  const applicationId = application._id;
-  delete application._id;
-
   return {
     query: `
       mutation updateApplication ($applicationId: String!, $data: ApplicationUpdate!) {
@@ -139,7 +137,7 @@ export function updateApplication(
     `,
     params: {
       applicationId,
-      data: application
+      data: applicationData
     }
   };
 }

--- a/packages/jscrambler-cli/src/mutations.js
+++ b/packages/jscrambler-cli/src/mutations.js
@@ -123,10 +123,13 @@ const updateApplicationDefaultFragments = `
 `;
 
 export function updateApplication(
-  applicationId,
   applicationData,
-  fragments = updateApplicationDefaultFragments
+  fragments = updateApplicationDefaultFragments,
+  applicationId = undefined,
 ) {
+  const appId = applicationId ?? applicationData._id;
+  delete applicationData._id;
+
   return {
     query: `
       mutation updateApplication ($applicationId: String!, $data: ApplicationUpdate!) {
@@ -136,7 +139,7 @@ export function updateApplication(
       }
     `,
     params: {
-      applicationId,
+      applicationId: appId,
       data: applicationData
     }
   };


### PR DESCRIPTION
The application update function (jscrambler-cli/src/index.js > updateApplication) was removing values from the payload, causing areSubscribersOrdered to not be returned in some responses.
Related to CD-8334.