### PR TITLE
Register package directory to assist tooling like Renovate bot.

### DIFF
--- a/.changeset/wicked-stingrays-shop.md
+++ b/.changeset/wicked-stingrays-shop.md
@@ -1,0 +1,10 @@
+---
+"jscrambler-webpack-plugin": patch
+"jscrambler-metro-plugin": patch
+"ember-cli-jscrambler": patch
+"grunt-jscrambler": patch
+"gulp-jscrambler": patch
+"jscrambler": patch
+---
+
+Better package metadata. This may assist tooling like Renovate bot.

--- a/packages/ember-cli-jscrambler/package.json
+++ b/packages/ember-cli-jscrambler/package.json
@@ -24,7 +24,8 @@
   "author": "Jscrambler <support@jscrambler.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jscrambler/jscrambler"
+    "url": "https://github.com/jscrambler/jscrambler.git",
+    "directory": "packages/ember-cli-jscrambler"
   },
   "dependencies": {
     "broccoli-plugin": "^1.3.0",

--- a/packages/grunt-jscrambler/package.json
+++ b/packages/grunt-jscrambler/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jscrambler/jscrambler.git"
+    "url": "https://github.com/jscrambler/jscrambler.git",
+    "directory": "packages/grunt-jscrambler"
   },
   "bugs": {
     "url": "https://github.com/jscrambler/jscrambler/issues"

--- a/packages/gulp-jscrambler/package.json
+++ b/packages/gulp-jscrambler/package.json
@@ -7,7 +7,8 @@
   "author": "Jscrambler <support@jscrambler.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jscrambler/jscrambler.git"
+    "url": "https://github.com/jscrambler/jscrambler.git",
+    "directory": "packages/gulp-jscrambler"
   },
   "bugs": {
     "url": "https://github.com/jscrambler/jscrambler/issues"

--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -6,7 +6,8 @@
   "author": "Jscrambler <support@jscrambler.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jscrambler/jscrambler.git"
+    "url": "https://github.com/jscrambler/jscrambler.git",
+    "directory": "packages/jscrambler-cli"
   },
   "bugs": {
     "url": "https://github.com/jscrambler/jscrambler/issues"

--- a/packages/jscrambler-metro-plugin/package.json
+++ b/packages/jscrambler-metro-plugin/package.json
@@ -29,6 +29,11 @@
   ],
   "author": "Jscrambler <support@jscrambler.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jscrambler/jscrambler.git",
+    "directory": "packages/jscrambler-metro-plugin"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/jscrambler-webpack-plugin/package.json
+++ b/packages/jscrambler-webpack-plugin/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jscrambler/jscrambler.git"
+    "url": "https://github.com/jscrambler/jscrambler.git",
+    "directory": "packages/jscrambler-webpack-plugin"
   },
   "keywords": [
     "jscrambler",


### PR DESCRIPTION
Renovate bot (and possibly other tools) is failing to display our CHANGELOGs properly.
It's possible that the monorepo structure is confusing the bot.
NPM has a standard way to indicate where a package lives, so we can and should fill it.

See also: https://github.com/renovatebot/renovate/issues/2926#issuecomment-575094237