### PR TITLE
fix: await to delete protection on success

### DIFF
--- a/.changeset/short-hats-serve.md
+++ b/.changeset/short-hats-serve.md
@@ -1,0 +1,5 @@
+---
+"jscrambler": patch
+---
+
+Added async behaviour to delete protection on success.

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -577,8 +577,8 @@ export default {
       }
 
       // change this to have the variable that checks if the protection is to be removed
-      if(deleteProtectionOnSuccess) {
-        this.removeProtection(client, protection._id, applicationId)
+      if (deleteProtectionOnSuccess) {
+        await this.removeProtection(client, protection._id, applicationId)
           .then(() => {
             if(debug) {
               console.log('Protection has been successful and will now be deleted')


### PR DESCRIPTION
I'm a user of jscrambler and tried to use the option `deleteProtectionOnSuccess` but the protections were never deleted because the operation to delete is async and the code needs to await for it. We need this fix in in a patch version, otherwise our VM fills up very quickly and have to manually delete the protections every few weeks.