### PR TITLE
fix(jscrambler-cli): missing proxy protocol option

### DIFF
--- a/.changeset/eighty-rocks-juggle.md
+++ b/.changeset/eighty-rocks-juggle.md
@@ -1,0 +1,5 @@
+---
+"jscrambler": patch
+---
+
+Added proxy protocol option

--- a/packages/jscrambler-cli/README.md
+++ b/packages/jscrambler-cli/README.md
@@ -284,6 +284,7 @@ If your requests need to go through a proxy, there is an option where you can sp
 ```
 {
   proxy: {
+    protocol: '', // 'http' by default
     host: '',
     port: 1234,
     auth: {

--- a/packages/jscrambler-cli/src/client.js
+++ b/packages/jscrambler-cli/src/client.js
@@ -210,19 +210,14 @@ JScramblerClient.prototype.request = function(
       formattedAuth = `${username}:${password}`;
     }
 
-      /**
-       * Monkey-patch to inject a custom Cert CA into TLS.connect
-       * options.
-       */
-      if (agentOptions.ca) {
-        const oriCallback = HttpsProxyAgent.prototype.callback;
-        HttpsProxyAgent.prototype.callback = function(req, opts) {
-          return oriCallback.call(this, req, {...opts, ...agentOptions})
-        }
-      }
-
     settings.proxy = false;
-    const proxyConfig = {host, port, auth: formattedAuth, ...agentOptions};
+    const proxyConfig = {
+      host,
+      port,
+      auth: formattedAuth,
+      protocol: proxy.protocol || "http",
+      ...agentOptions,
+    };
     settings.httpsAgent = new HttpsProxyAgent(proxyConfig);
     settings.httpAgent = new HttpProxyAgent(proxyConfig);
   } else if(agentOptions) {


### PR DESCRIPTION
* add `proxy.protocol` option (http by default)