### PR TITLE
Enable option on gulp jscrambler

### DIFF
--- a/.changeset/great-nails-reply.md
+++ b/.changeset/great-nails-reply.md
@@ -1,0 +1,5 @@
+---
+"gulp-jscrambler": minor
+---
+
+Added enable option

--- a/packages/gulp-jscrambler/README.md
+++ b/packages/gulp-jscrambler/README.md
@@ -33,8 +33,16 @@ In order to start using gulp-jscrambler you will need to add a new task to your 
 Here's an example of how Jscrambler task should look like:
 
 ```js
-var gulp = require('gulp');
-var jscrambler = require('gulp-jscrambler');
+const gulp = require('gulp');
+const jscrambler = require('gulp-jscrambler');
+
+function enable(filesSrc) {
+  if (filesSrc.length === 0) {
+    return false;
+  }
+
+  return true;
+}
 
 gulp.task('default', function (done) {
   gulp
@@ -45,6 +53,7 @@ gulp.task('default', function (done) {
         secretKey: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       },
       applicationId: 'XXXXXXXXXXXX',
+      enable,
       params: [
         {
           name: 'whitespaceRemoval'
@@ -71,6 +80,8 @@ You can also grab your current configuration on your application page. This will
 ![download config file location](https://blog.jscrambler.com/content/images/2018/08/jscrambler-101-first-use-download-json.png)
 
 Keep in mind that the `params` object is optional and if it is not provided we will use your previous configuration.
+
+The `enable` object is an optional function (returns true by default) that will allow to manipulate the files sources and decide if you want to protect them (returning true) or skip (returning false). The example provided before is a use case that will skip the Jscrambler protection when there isn't any files on source.
 
 ### Usage Example
 

--- a/packages/gulp-jscrambler/index.js
+++ b/packages/gulp-jscrambler/index.js
@@ -12,6 +12,7 @@ module.exports = function (options) {
     cwd: process.cwd(),
     filesSrc: [],
     keys: {},
+    enable: () => true,
     clientId: 3
   });
 
@@ -22,7 +23,7 @@ module.exports = function (options) {
 
   var aggregate = function (file, enc, next) {
     if (file.isBuffer()) {
-      if (file.stat.size === 0) {
+      if (file.contents.length === 0) {
         emptyFiles.push(file);
       } else {
         options.filesSrc.push(file);
@@ -39,7 +40,20 @@ module.exports = function (options) {
     var self = this;
     // Empty files should not be protected
     if (emptyFiles.length > 0) {
-      self.push(...emptyFiles);
+      emptyFiles.forEach((file) => {
+        file.base = null;
+        self.push(file)
+      })
+    }
+    if (!options.enable(options.filesSrc)) {
+      if (options.filesSrc.length > 0) {
+        options.filesSrc.forEach((file) => {
+          file.base = null;
+          self.push(file);
+        });
+      }
+      console.log('Skipping Jscrambler protection...');
+      return done(null);
     }
     var dest = function (buffer, filename) {
       var file = null;


### PR DESCRIPTION
Enable option allow the user to manipulate files sources and allow to skip jscrambler protection.