### PR TITLE
feat: introduce experimentalOptions field

### DIFF
--- a/.changeset/angry-badgers-flow.md
+++ b/.changeset/angry-badgers-flow.md
@@ -1,0 +1,14 @@
+---
+"jscrambler": minor
+"ember-cli-jscrambler": minor
+"grunt-jscrambler": minor
+"gulp-jscrambler": minor
+"jscrambler-metro-plugin": minor
+"jscrambler-webpack-plugin": minor
+---
+
+New feature: experimentalOptions.
+
+Users can pass experimental features through this field to our API.
+The exact features aren't publicly documented. The expectation is that users are using these flags only
+when advised to by our support team.

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -411,6 +411,7 @@ const {
   forceAppEnvironment,
   beforeProtection,
   deleteProtectionOnSuccess,
+  experimentalOptions,
 } = config;
 
 const params = config.params;
@@ -549,6 +550,7 @@ if (commander.sourceMaps) {
       forceAppEnvironment,
       beforeProtection,
       deleteProtectionOnSuccess,
+      experimentalOptions,
     };
     try {
       if (typeof werror !== 'undefined') {

--- a/packages/jscrambler-cli/src/cleanup-input-fields.js
+++ b/packages/jscrambler-cli/src/cleanup-input-fields.js
@@ -18,7 +18,15 @@ export default function cleanupInputFields(args, fragments, options = {}) {
     }
   }
 
-  ['tolerateMinification', 'useProfilingData', 'useAppClassification', 'inputSymbolTable', 'entryPoint', 'ensureCodeAnnotation'].forEach(fieldCleanUp);
+  [
+    'tolerateMinification',
+    'useProfilingData',
+    'useAppClassification',
+    'inputSymbolTable',
+    'entryPoint',
+    'ensureCodeAnnotation',
+    'experimentalOptions',
+  ].forEach(fieldCleanUp);
 
   return [options, cleanedUpFragments];
 }

--- a/packages/jscrambler-cli/src/index.js
+++ b/packages/jscrambler-cli/src/index.js
@@ -448,7 +448,7 @@ export default {
       source,
       tolerateMinification,
       numberOfProtections,
-      forceAppEnvironment
+      forceAppEnvironment,
     };
 
     if (finalConfig.inputSymbolTable) {
@@ -457,6 +457,10 @@ export default {
         'utf-8',
       );
       protectionOptions.inputSymbolTable = inputSymbolTableContents;
+    }
+
+    if (finalConfig.experimentalOptions) {
+      protectionOptions.experimentalOptions = finalConfig.experimentalOptions;
     }
 
     const createApplicationProtectionRes = await this.createApplicationProtections(


### PR DESCRIPTION
New feature: experimentalOptions.

Users can pass experimental features through this field to our API.
The exact features aren't publicly documented. The expectation is that users are using these flags only
when advised to by our support team.