### PR TITLE
chore(metro-plugin): columnStart should only be applied to first line

### DIFF
--- a/.changeset/fluffy-lions-explode.md
+++ b/.changeset/fluffy-lions-explode.md
@@ -1,0 +1,5 @@
+---
+"jscrambler-metro-plugin": patch
+---
+
+Metro-Plugin SourceMaps: apply columnStart only to the first line

--- a/packages/jscrambler-metro-plugin/lib/sourceMaps.js
+++ b/packages/jscrambler-metro-plugin/lib/sourceMaps.js
@@ -105,7 +105,11 @@ module.exports = async function generateSourceMaps(payload) {
       const allGeneratedPositionsFor = ofuscatedSourceMapConsumers[fileNamesIndex].allGeneratedPositionsFor({
         source: normalizePath,
         line: mapping.generatedLine - lineStart + 1 /* avoid line=0 */,
-        column: mapping.generatedColumn - columnStart
+        column:
+          mapping.generatedColumn -
+          (mapping.generatedLine === lineStart
+            ? columnStart /* column start should be applied only to the first line */
+            : 0),
       });
 
       if (allGeneratedPositionsFor.length === 0) {


### PR DESCRIPTION
### Reproduce

* create a reactive-native project with `react-native init test` command
* change metro.config.js file to include jscrambler-plugin and allow comments
```
const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
const jscramblerMetroPlugin = require("jscrambler-metro-plugin")();

/**
 * Metro configuration
 * https://reactnative.dev/docs/metro
 *
 * @type {import('metro-config').MetroConfig}
 */
const config = { 
  // if you have other metro configs, add here
  ...jscramblerMetroPlugin,
	transformer: {
    minifierConfig: {
      compress: false,
	    output: {
		    comments: true
	    }
    }
  }
};

module.exports = mergeConfig(getDefaultConfig(__dirname), config);
```
* add `.jscramblerrc` with antiTampering and enable sourceMaps

### Error

`TypeError: Column must be greater than or equal to 0, got -16`

### Cause

In the source-maps generation logic the `columnStart` option should only be applied to the first line of the source file. 

Some metro minifier options cause the file to have multiple lines instead of the usually one line production version.   