### PR TITLE
fix: remove unused dependencies

### DIFF
--- a/.changeset/violet-suns-hammer.md
+++ b/.changeset/violet-suns-hammer.md
@@ -2,4 +2,4 @@
 "jscrambler": patch
 ---
 
-remove unused dependencies, specially temp which has vulnerabilites
+remove unused dependencies, and bump others, specially due to vulnerabilites

--- a/.changeset/violet-suns-hammer.md
+++ b/.changeset/violet-suns-hammer.md
@@ -1,0 +1,5 @@
+---
+"jscrambler": patch
+---
+
+remove unused dependencies, specially temp which has vulnerabilites

--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "axios": "^1.4.0",
     "commander": "^2.8.1",
-    "core-js": "^3.16.4",
     "filesize-parser": "1.5.0",
     "glob": "^8.1.0",
     "http-proxy-agent": "7.0.2",
@@ -42,10 +41,7 @@
     "lodash.defaults": "^4.0.1",
     "lodash.keys": "^4.0.1",
     "lodash.size": "^4.0.1",
-    "q": "^1.4.1",
-    "rc": "^1.1.0",
-    "snake-case": "^2.1.0",
-    "temp": "^0.8.3"
+    "rc": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.4",

--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -29,7 +29,7 @@
     "node": ">= 12.17.0"
   },
   "dependencies": {
-    "axios": "^1.4.0",
+    "axios": "^1.7.2",
     "commander": "^2.8.1",
     "filesize-parser": "1.5.0",
     "glob": "^8.1.0",

--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -35,7 +35,7 @@
     "glob": "^8.1.0",
     "http-proxy-agent": "7.0.2",
     "https-proxy-agent": "7.0.4",
-    "jszip": "^3.7.1",
+    "jszip": "^3.8.0",
     "lodash.clone": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.defaults": "^4.0.1",


### PR DESCRIPTION
Remove unused dependencies. 
temp dependency has rimraf@2.6.2, which in turn depends on glob@7.2.0, which depends on minimatch@3.0.4, which is vulnerable.
axios and jszip have vulnerabilites, bumped.