### PR TITLE
fix: add error when using mode with version <8.4

### DIFF
--- a/.changeset/tiny-paws-sip.md
+++ b/.changeset/tiny-paws-sip.md
@@ -1,0 +1,5 @@
+---
+"jscrambler": patch
+---
+
+Add error when trying to use mode setting with jscrambler version inferior to 8.4

--- a/packages/jscrambler-cli/src/bin/jscrambler.js
+++ b/packages/jscrambler-cli/src/bin/jscrambler.js
@@ -463,6 +463,11 @@ if (usedIncompatibleOptions.length > 1) {
   process.exit(1);
 }
 
+if ((commander.mode || config.mode) && Number(jscramblerVersion) < 8.4) {
+  console.error('Mode setting is only available from version 8.4 on.');
+  process.exit(1);
+}
+
 if (
   (commander.mode === 'automatic' || config.mode === 'automatic') &&
   config.params


### PR DESCRIPTION
Mode is a setting that should only be used on versions 8.4 and after.
So, we should have a clear error on the CLI covering the cases where it does not, otherwise , the error will come from the API and be too confusing.