### PR TITLE
Fix beforeProtection and cwd options compatibility

### DIFF
--- a/.changeset/cool-months-move.md
+++ b/.changeset/cool-months-move.md
@@ -1,0 +1,5 @@
+---
+"jscrambler": patch
+---
+
+fix compatibility of cwd and beforeProtection options

--- a/packages/jscrambler-cli/src/utils.js
+++ b/packages/jscrambler-cli/src/utils.js
@@ -69,10 +69,6 @@ function handleScriptConcatenation (firstFile, secondFile) {
 export function concatenate (scriptObject, cwd, path, buffer) {
   let { target } = scriptObject;
 
-  if(cwd) {
-    target = join(cwd, target);
-  }
-
   target = normalize(target);
 
   if(target === path) {


### PR DESCRIPTION
The option cwd is currently only used for writing purposes (after protection).
However, in the beforeProtection entries, it is concatenated to the target files, while the verification for file existence is made without the concatenation, leading to the prepend/append never happening to the targeted file.