### PR TITLE
test(jscrambler-cli): add Jest tests and config for utils

### DIFF
--- a/packages/jscrambler-cli/babel.config.js
+++ b/packages/jscrambler-cli/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/packages/jscrambler-cli/jest.config.js
+++ b/packages/jscrambler-cli/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.js'],
+};

--- a/packages/jscrambler-cli/package.json
+++ b/packages/jscrambler-cli/package.json
@@ -23,7 +23,8 @@
     "watch": "babel -w src --out-dir dist",
     "prepublish": "npm run build",
     "eslint": "eslint src/",
-    "eslint:fix": "eslint src/ --fix"
+    "eslint:fix": "eslint src/ --fix",
+    "test": "jest"
   },
   "engines": {
     "node": ">= 12.17.0"
@@ -47,7 +48,9 @@
   "devDependencies": {
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.7",
-    "@babel/preset-env": "^7.23.8"
+    "@babel/preset-env": "^7.23.8",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
   },
   "files": [
     "dist",

--- a/packages/jscrambler-cli/src/__tests__/utils.test.js
+++ b/packages/jscrambler-cli/src/__tests__/utils.test.js
@@ -1,0 +1,140 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  APPEND_JS_TYPE,
+  PREPEND_JS_TYPE,
+  concatenate,
+  getMatchedFiles,
+  validateNProtections,
+  validateThresholdFn,
+} from '../utils.js';
+
+describe('utils', () => {
+  describe('getMatchedFiles', () => {
+    it('returns matches for a glob pattern', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const files = ['alpha.js', 'beta.js'];
+      files.forEach((file) => {
+        fs.writeFileSync(path.join(tempDir, file), '// test');
+      });
+
+      const matched = getMatchedFiles(path.join(tempDir, '*.js'));
+
+      expect(matched.sort()).toEqual(
+        files.map((file) => path.join(tempDir, file)).sort(),
+      );
+    });
+
+    it('returns the file when the pattern is a literal file name', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const fileName = '[id]-1234.js';
+      const filePath = path.join(tempDir, fileName);
+      fs.writeFileSync(filePath, '// test');
+
+      const matched = getMatchedFiles(filePath);
+
+      expect(matched).toEqual([filePath]);
+    });
+  });
+
+  describe('validateNProtections', () => {
+    it('returns undefined when no value is provided', () => {
+      expect(validateNProtections(undefined)).toBeUndefined();
+    });
+
+    it('returns a parsed integer when valid', () => {
+      expect(validateNProtections('2')).toBe(2);
+    });
+
+    it('exits when the value is invalid', () => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => validateNProtections('0')).toThrow('process.exit');
+      expect(errorSpy).toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('validateThresholdFn', () => {
+    it('parses thresholds into bytes', () => {
+      const threshold = validateThresholdFn('threshold');
+      expect(threshold('200kb')).toBe(204800);
+    });
+
+    it('exits when the value is invalid', () => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const threshold = validateThresholdFn('threshold');
+      expect(() => threshold('nope')).toThrow('process.exit');
+      expect(errorSpy).toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('concatenate', () => {
+    it('appends scripts to the target file', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const targetPath = path.join(tempDir, 'target.js');
+      const scriptPath = path.join(tempDir, 'script.js');
+      fs.writeFileSync(scriptPath, 'console.log("script");');
+
+      const buffer = Buffer.from('console.log("target");', 'utf-8');
+      const result = concatenate(
+        { target: targetPath, source: scriptPath, type: APPEND_JS_TYPE },
+        tempDir,
+        targetPath,
+        buffer,
+      );
+
+      expect(result.toString('utf-8')).toBe(
+        'console.log("target");\nconsole.log("script");',
+      );
+    });
+
+    it('prepends scripts to the target file', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const targetPath = path.join(tempDir, 'target.js');
+      const scriptPath = path.join(tempDir, 'script.js');
+      fs.writeFileSync(scriptPath, 'console.log("script");');
+
+      const buffer = Buffer.from('console.log("target");', 'utf-8');
+      const result = concatenate(
+        { target: targetPath, source: scriptPath, type: PREPEND_JS_TYPE },
+        tempDir,
+        targetPath,
+        buffer,
+      );
+
+      expect(result.toString('utf-8')).toBe(
+        'console.log("script");\nconsole.log("target");',
+      );
+    });
+
+    it('throws when the script file is missing', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const targetPath = path.join(tempDir, 'target.js');
+      const scriptPath = path.join(tempDir, 'missing.js');
+      const buffer = Buffer.from('console.log("target");', 'utf-8');
+
+      expect(() =>
+        concatenate(
+          { target: targetPath, source: scriptPath, type: PREPEND_JS_TYPE },
+          tempDir,
+          targetPath,
+          buffer,
+        ),
+      ).toThrow('Provided script file does not exist');
+    });
+  });
+});

--- a/packages/jscrambler-cli/src/__tests__/utils.test.js
+++ b/packages/jscrambler-cli/src/__tests__/utils.test.js
@@ -6,6 +6,7 @@ import {
   PREPEND_JS_TYPE,
   concatenate,
   getMatchedFiles,
+  isJavascriptFile,
   validateNProtections,
   validateThresholdFn,
 } from '../utils.js';
@@ -36,6 +37,13 @@ describe('utils', () => {
 
       expect(matched).toEqual([filePath]);
     });
+
+    it('returns an empty array when nothing matches', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const matched = getMatchedFiles(path.join(tempDir, '*.js'));
+
+      expect(matched).toEqual([]);
+    });
   });
 
   describe('validateNProtections', () => {
@@ -54,6 +62,19 @@ describe('utils', () => {
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
       expect(() => validateNProtections('0')).toThrow('process.exit');
+      expect(errorSpy).toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('exits when the value is not an integer', () => {
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => validateNProtections('2.5')).toThrow('process.exit');
       expect(errorSpy).toHaveBeenCalled();
 
       exitSpy.mockRestore();
@@ -79,6 +100,19 @@ describe('utils', () => {
 
       exitSpy.mockRestore();
       errorSpy.mockRestore();
+    });
+  });
+
+  describe('isJavascriptFile', () => {
+    it('returns true for .js, .mjs, and .cjs files', () => {
+      expect(isJavascriptFile('file.js')).toBe(true);
+      expect(isJavascriptFile('file.mjs')).toBe(true);
+      expect(isJavascriptFile('file.cjs')).toBe(true);
+    });
+
+    it('returns false for non-JavaScript extensions', () => {
+      expect(isJavascriptFile('file.ts')).toBe(false);
+      expect(isJavascriptFile('file.json')).toBe(false);
     });
   });
 
@@ -135,6 +169,25 @@ describe('utils', () => {
           buffer,
         ),
       ).toThrow('Provided script file does not exist');
+    });
+
+    it('returns the original buffer when the path does not match the target', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jscrambler-cli-'));
+      const targetPath = path.join(tempDir, 'target.js');
+      const otherPath = path.join(tempDir, 'other.js');
+      const scriptPath = path.join(tempDir, 'script.js');
+      fs.writeFileSync(scriptPath, 'console.log("script");');
+
+      const buffer = Buffer.from('console.log("target");', 'utf-8');
+      const result = concatenate(
+        { target: targetPath, source: scriptPath, type: PREPEND_JS_TYPE },
+        tempDir,
+        otherPath,
+        buffer,
+      );
+
+      expect(result).toBe(buffer);
+      expect(result.toString('utf-8')).toBe('console.log("target");');
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Add unit tests for the `jscrambler-cli` package to validate utility helpers and increase test coverage.
- Enable running tests with Jest in a Node environment using Babel for ES module support.

### Description
- Added a `test` script and Jest devDependencies (`jest`, `babel-jest`) to `packages/jscrambler-cli/package.json` and kept existing Babel deps. 
- Added `packages/jscrambler-cli/babel.config.js` to target the current Node for test transpilation. 
- Added `packages/jscrambler-cli/jest.config.js` to configure `testEnvironment` and `testMatch` for the package. 
- Added unit tests at `packages/jscrambler-cli/src/__tests__/utils.test.js` covering `getMatchedFiles`, `validateNProtections`, `validateThresholdFn`, and `concatenate` behaviors.

### Testing
- Ran `pnpm --filter jscrambler test` which failed because `jest` was not available in the environment (`sh: 1: jest: not found`).
- Attempted `pnpm --filter jscrambler install` to install dev dependencies which failed due to a registry permission error fetching `@babel/cli` (HTTP 403) so tests could not be executed locally. 
- No Jest test run succeeded in this environment due to dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e7d9611d883339b3233b179619f87)