### PR TITLE
[codex] Support mjs and cjs webpack assets

### DIFF
--- a/.changeset/protect-mjs-cjs-webpack-assets.md
+++ b/.changeset/protect-mjs-cjs-webpack-assets.md
@@ -1,0 +1,5 @@
+---
+"jscrambler-webpack-plugin": patch
+---
+
+Protect webpack-emitted `.mjs` and `.cjs` assets.

--- a/packages/jscrambler-webpack-plugin/package.json
+++ b/packages/jscrambler-webpack-plugin/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "babel src --out-dir lib",
+    "test": "node test/index.js",
     "eslint": "eslint src/",
     "eslint:fix": "pnpm run eslint --fix"
   },

--- a/packages/jscrambler-webpack-plugin/src/index.js
+++ b/packages/jscrambler-webpack-plugin/src/index.js
@@ -11,6 +11,8 @@ const JSCRAMBLER_IGNORE = '.jscramblerignore';
 const sourceMaps = !!client.config.sourceMaps;
 const instrument = !!client.config.instrument;
 const PLUGIN_NAME = 'JscramblerPlugin';
+const PROTECTABLE_ASSET_REGEX = /\.(js|mjs|cjs|html|htm)$/;
+const SOURCE_MAP_ASSET_REGEX = /\.(js|mjs|cjs)\.map$/;
 const OBFUSCATION_LEVELS = {
   MODULE: 'module',
   BUNDLE: 'bundle'
@@ -239,7 +241,7 @@ class JscramblerPlugin {
    */
   getSourceMapInfo(filename, compilation) {
     let sourceMapFilename = `${filename}.map`;
-    if (/\.(js.map)$/.test(filename)) {
+    if (SOURCE_MAP_ASSET_REGEX.test(filename)) {
       sourceMapFilename = filename;
     }
     const sourceMap = compilation.assets[sourceMapFilename];
@@ -266,7 +268,7 @@ class JscramblerPlugin {
         }
 
         chunk.files.forEach(filename => {
-          if (/\.(js|html|htm)$/.test(filename)) {
+          if (PROTECTABLE_ASSET_REGEX.test(filename)) {
             const content = compilation.assets[filename].source();
 
             if (this.options.obfuscationLevel === OBFUSCATION_LEVELS.BUNDLE) {

--- a/packages/jscrambler-webpack-plugin/test/index.js
+++ b/packages/jscrambler-webpack-plugin/test/index.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('assert');
+const client = require('jscrambler').default;
+
+const originalProtectAndDownload = client.protectAndDownload;
+const originalConfig = client.config;
+
+client.config = Object.assign({}, client.config, {
+  instrument: false,
+  sourceMaps: false
+});
+
+const JscramblerPlugin = require('../src/index');
+
+function asset(content) {
+  return {
+    source() {
+      return content;
+    },
+    size() {
+      return content.length;
+    }
+  };
+}
+
+async function collectProtectedFiles() {
+  let protectedFilenames = [];
+
+  client.protectAndDownload = (options, callback) => {
+    protectedFilenames = options.sources.map(({filename}) => filename);
+    callback(options.sources.map(({filename}) => ({
+      filename,
+      content: `protected:${filename}`
+    })));
+
+    return 'protection-id';
+  };
+
+  const plugin = new JscramblerPlugin({obfuscationHook: 'emit'});
+  let emitHandler;
+
+  plugin.apply({
+    plugin(name, handler) {
+      assert.strictEqual(name, 'emit');
+      emitHandler = handler;
+    }
+  });
+
+  const compilation = {
+    assets: {
+      'app.js': asset('js'),
+      'app.mjs': asset('mjs'),
+      'app.cjs': asset('cjs'),
+      'index.html': asset('html'),
+      'partial.htm': asset('htm'),
+      'styles.css': asset('css'),
+      'app.mjs.map': asset('map')
+    },
+    chunks: [
+      {
+        files: [
+          'app.js',
+          'app.mjs',
+          'app.cjs',
+          'index.html',
+          'partial.htm',
+          'styles.css',
+          'app.mjs.map'
+        ]
+      }
+    ]
+  };
+
+  await new Promise((resolve, reject) => {
+    emitHandler(compilation, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return {plugin, protectedFilenames};
+}
+
+(async () => {
+  try {
+    const {plugin, protectedFilenames} = await collectProtectedFiles();
+
+    assert.deepStrictEqual(protectedFilenames, [
+      'app.js',
+      'app.mjs',
+      'app.cjs',
+      'index.html',
+      'partial.htm'
+    ]);
+
+    const mapCompilation = {
+      assets: {
+        'app.mjs.map': asset('mjs map'),
+        'app.cjs.map': asset('cjs map')
+      }
+    };
+
+    assert.strictEqual(
+      plugin.getSourceMapInfo('app.mjs.map', mapCompilation).sourceMapFilename,
+      'app.mjs.map'
+    );
+    assert.strictEqual(
+      plugin.getSourceMapInfo('app.cjs.map', mapCompilation).sourceMapFilename,
+      'app.cjs.map'
+    );
+  } finally {
+    client.protectAndDownload = originalProtectAndDownload;
+    client.config = originalConfig;
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Extend the webpack plugin asset matcher to protect `.mjs` and `.cjs` bundles in addition to existing `.js` and HTML assets.
- Recognize `.mjs.map` and `.cjs.map` assets when sourcemaps are present in webpack chunk files.
- Add a small package-local test for protected asset collection and sourcemap filename handling.
- Add a patch changeset for `jscrambler-webpack-plugin`.

## Why

NativeScript 9 can emit ES module bundles as `.mjs`, which were skipped by the plugin because the protected asset regex only matched `.js`, `.html`, and `.htm`. `.cjs` is also a JavaScript bundle extension and had the same gap.

Closes #309.

## Validation

- `pnpm --filter jscrambler-webpack-plugin test`
- `pnpm --filter jscrambler-webpack-plugin build`
- `git diff --check`