### PR TITLE
chore(security-advisory): remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # [![Jscrambler](https://media.jscrambler.com/images/logo_500px.png)](https://jscrambler.com/?utm_source=github.com&utm_medium=referral)
 
-> [!IMPORTANT]
-> **Security advisory (11/07/2026):** [Unauthorized Publication of a Malicious npm Package affecting CI](https://jscrambler.com/blog/security-advisory-malicious-npm-package)
-
 ## Jscrambler Code Integrity
 
 Jscrambler [Code Integrity](https://jscrambler.com/code-integrity) is a JavaScript protection technology for Web and Mobile Applications. Its main purpose is to enable JavaScript applications to become self-defensive and resilient to tampering and reverse engineering. 

--- a/packages/jscrambler-cli/README.md
+++ b/packages/jscrambler-cli/README.md
@@ -1,8 +1,5 @@
 # [![Jscrambler](https://media.jscrambler.com/images/logo_500px.png)](https://jscrambler.com/?utm_source=github.com&utm_medium=referral)
 
-> [!IMPORTANT]
-> **Security advisory (11/07/2026):** [Unauthorized Publication of a Malicious npm Package affecting CI](https://jscrambler.com/blog/security-advisory-malicious-npm-package)
-
 Jscrambler Code Integrity Client
 --------------------
 


### PR DESCRIPTION
We can remove the security advisory because:

* All compromised packages were removed from npm
* All security assessements and audits were completed
* Compromised packages were added to the [Github Advisory Database](https://github.com/advisories/GHSA-v3g3-4x77-rw68)
* Security incident Post-Mortem was [published](https://jscrambler.com/blog/security-incident-postmortem-jscrambler/)